### PR TITLE
Feat/pe 142/storefront header

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,3 +15,4 @@ export * from './modules/checkout';
 export * from './modules/dashboard';
 export * from './modules/addFunds';
 export * from './modules/poll';
+export * from './modules/storefront';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -7,3 +7,4 @@ export * from './dashboard';
 export * from './addFunds';
 export * from './pass';
 export * from './poll';
+export * from './storefront';

--- a/src/modules/shared/components/HeaderPixwaySDK/HeaderPixwaySDK.tsx
+++ b/src/modules/shared/components/HeaderPixwaySDK/HeaderPixwaySDK.tsx
@@ -78,16 +78,16 @@ const _HeaderPixwaySDK = ({
       >
         <div className="pw-flex pw-justify-between pw-py-5 pw-items-center">
           <a href={PixwayAppRoutes.HOME}>
-            {brandText ? (
-              <p className="pw-font-poppins pw-text-[16px] pw-font-[600]">
-                {brandText}
-              </p>
-            ) : (
+            {logoUrl ? (
               <img
                 style={{ height: logoHeight + 'px' }}
                 src={logoUrl}
                 className="pw-object-contain pw-max-w-[150px]"
               />
+            ) : (
+              <p className="pw-font-poppins pw-text-[16px] pw-font-[600]">
+                {brandText}
+              </p>
             )}
           </a>
 

--- a/src/modules/shared/components/HeaderPixwaySDK/HeaderPixwaySDK.tsx
+++ b/src/modules/shared/components/HeaderPixwaySDK/HeaderPixwaySDK.tsx
@@ -26,6 +26,7 @@ interface HeaderPixwaySDKProps {
   bgColor?: string;
   textColor?: string;
   hasSignUp?: boolean;
+  brandText?: string;
 }
 
 const _HeaderPixwaySDK = ({
@@ -41,6 +42,7 @@ const _HeaderPixwaySDK = ({
   bgColor = 'white',
   textColor = 'black',
   hasSignUp = true,
+  brandText = '',
 }: HeaderPixwaySDKProps) => {
   const [openedTabs, setOpenedTabs] = useState<boolean>(false);
   const [openedloginState, setopenedLoginState] = useState<boolean>(false);
@@ -76,11 +78,17 @@ const _HeaderPixwaySDK = ({
       >
         <div className="pw-flex pw-justify-between pw-py-5 pw-items-center">
           <a href={PixwayAppRoutes.HOME}>
-            <img
-              style={{ height: logoHeight + 'px' }}
-              src={logoUrl}
-              className=" pw-object-contain pw-max-w-[150px]"
-            />
+            {brandText ? (
+              <p className="pw-font-poppins pw-text-[16px] pw-font-[600]">
+                {brandText}
+              </p>
+            ) : (
+              <img
+                style={{ height: logoHeight + 'px' }}
+                src={logoUrl}
+                className="pw-object-contain pw-max-w-[150px]"
+              />
+            )}
           </a>
 
           <div className="pw-flex pw-items-center">

--- a/src/modules/storefront/components/Header.tsx
+++ b/src/modules/storefront/components/Header.tsx
@@ -1,0 +1,22 @@
+import { HeaderPixwaySDK } from '../../shared';
+import { HeaderData, HeaderDefault } from '../interfaces';
+
+export const Header = ({
+  data,
+  defaultData,
+}: {
+  data: HeaderData;
+  defaultData: HeaderDefault;
+}) => {
+  const backgroundColor = data.bgColor || defaultData.bgColor;
+  const color = data.textColor || defaultData.textColor;
+  const brandText = data.brandText;
+
+  return (
+    <HeaderPixwaySDK
+      bgColor={backgroundColor}
+      textColor={color}
+      brandText={brandText}
+    />
+  );
+};

--- a/src/modules/storefront/components/Header.tsx
+++ b/src/modules/storefront/components/Header.tsx
@@ -1,5 +1,12 @@
 import { HeaderPixwaySDK } from '../../shared';
-import { HeaderData, HeaderDefault } from '../interfaces';
+import {
+  BannerData,
+  BannerDefault,
+  HeaderData,
+  HeaderDefault,
+  HeroData,
+  HeroDefault,
+} from '../interfaces';
 
 export const Header = ({
   data,
@@ -19,4 +26,24 @@ export const Header = ({
       brandText={brandText}
     />
   );
+};
+
+export const Banner = ({
+  data,
+  defaultData,
+}: {
+  data: BannerData;
+  defaultData: BannerDefault;
+}) => {
+  return <>{JSON.stringify({ ...data, ...defaultData })}</>;
+};
+
+export const Hero = ({
+  data,
+  defaultData,
+}: {
+  data: HeroData;
+  defaultData: HeroDefault;
+}) => {
+  return <>{JSON.stringify({ ...data, ...defaultData })}</>;
 };

--- a/src/modules/storefront/components/StorefrontPreview.tsx
+++ b/src/modules/storefront/components/StorefrontPreview.tsx
@@ -22,15 +22,9 @@ const Storefront = () => {
     return () => window.removeEventListener('message', listener);
   });
 
-  console.log('My Context: ', context);
-
   const safeOrigin = 'http://localhost:3000/';
   const listener = (event: MessageEvent<TemplateData | string>) => {
-    console.log('Event Origin: ', event.origin);
-
     if (event.origin !== safeOrigin) return;
-
-    console.log('Received some data: ', event.data);
 
     if (typeof event.data === 'string') return context?.setPageName(event.data);
 
@@ -40,16 +34,19 @@ const Storefront = () => {
   const data = { ...context?.pageTheme, ...currentTheme };
   const themeContext = context?.defaultTheme;
 
+  if (!themeContext) return null;
+
   return (
     <>
       {data.items?.map((item) => {
         const Component = componentMap[item.type];
-        const props = {
-          defaultData: themeContext?.[item.type],
-          data: item.props,
-        };
-
-        return <Component key={item.type} {...(props as any)} />;
+        return (
+          <Component
+            key={item.type}
+            data={item.props}
+            defaultData={themeContext[item.type]}
+          />
+        );
       })}
     </>
   );

--- a/src/modules/storefront/components/StorefrontPreview.tsx
+++ b/src/modules/storefront/components/StorefrontPreview.tsx
@@ -1,0 +1,61 @@
+import { useContext, useState } from 'react';
+import { useEffectOnce } from 'react-use';
+
+import { ThemeContext, ThemeProvider } from '../contexts';
+import { TemplateData } from '../interfaces';
+import { Header } from './Header';
+
+export const StorefrontPreview = () => {
+  return (
+    <ThemeProvider>
+      <Storefront />
+    </ThemeProvider>
+  );
+};
+
+const Storefront = () => {
+  const context = useContext(ThemeContext);
+  const [currentTheme, setCurrentTheme] = useState<TemplateData | null>(null);
+  useEffectOnce(() => {
+    window.addEventListener('message', listener);
+
+    return () => window.removeEventListener('message', listener);
+  });
+
+  console.log('My Context: ', context);
+
+  const safeOrigin = 'http://localhost:3000/';
+  const listener = (event: MessageEvent<TemplateData | string>) => {
+    console.log('Event Origin: ', event.origin);
+
+    if (event.origin !== safeOrigin) return;
+
+    console.log('Received some data: ', event.data);
+
+    if (typeof event.data === 'string') return context?.setPageName(event.data);
+
+    setCurrentTheme(event.data);
+  };
+
+  const data = { ...context?.pageTheme, ...currentTheme };
+  const themeContext = context?.defaultTheme;
+
+  return (
+    <>
+      {data.items?.map((item) => {
+        const Component = componentMap[item.type];
+        const props = {
+          defaultData: themeContext?.[item.type],
+          data: item.props,
+        };
+
+        return <Component key={item.type} {...(props as any)} />;
+      })}
+    </>
+  );
+};
+
+const componentMap = {
+  header: Header,
+  banner: () => <></>,
+};

--- a/src/modules/storefront/components/StorefrontPreview.tsx
+++ b/src/modules/storefront/components/StorefrontPreview.tsx
@@ -2,8 +2,8 @@ import { useContext, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { ThemeContext, ThemeProvider } from '../contexts';
-import { TemplateData } from '../interfaces';
-import { Header } from './Header';
+import { DefaultDataProps, TemplateData } from '../interfaces';
+import { Banner, Header, Hero } from './Header';
 
 export const StorefrontPreview = () => {
   return (
@@ -38,13 +38,15 @@ const Storefront = () => {
 
   return (
     <>
-      {data.items?.map((item) => {
+      {data.items?.map((item, i) => {
         const Component = componentMap[item.type];
         return (
           <Component
-            key={item.type}
+            key={item.type + i}
             data={item.props}
-            defaultData={themeContext[item.type]}
+            defaultData={
+              themeContext[item.type] as keyof DefaultDataProps['defaultData']
+            }
           />
         );
       })}
@@ -54,5 +56,6 @@ const Storefront = () => {
 
 const componentMap = {
   header: Header,
-  banner: () => <></>,
+  banner: Banner,
+  hero: Hero,
 };

--- a/src/modules/storefront/components/index.ts
+++ b/src/modules/storefront/components/index.ts
@@ -1,0 +1,1 @@
+export * from './StorefrontPreview';

--- a/src/modules/storefront/contexts/ThemeContext/ThemeContext.tsx
+++ b/src/modules/storefront/contexts/ThemeContext/ThemeContext.tsx
@@ -1,0 +1,96 @@
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import { useEffectOnce } from 'react-use';
+
+import { Template, TemplateData } from '../../interfaces';
+
+export const ThemeContext = createContext<IThemeContext | null>(null);
+interface IThemeContext {
+  defaultTheme: Template | null;
+  pageTheme: TemplateData | null;
+  setPageName: Dispatch<SetStateAction<string>>;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const [defaultTheme, setDefaultTheme] = useState<Template | null>(null);
+  const [pageTheme, setPageTheme] = useState<TemplateData | null>(null);
+  const [pageName, setPageName] = useState('');
+
+  useEffectOnce(() => {
+    //requisição pra pegar valores default
+    // const baseURL = "https://api.w3block.io";
+    // const location = "primesea.io";
+    // const url = `${baseURL}/storefrontTheme?site=${location}`;
+    setDefaultTheme(sampleTemplate);
+  });
+
+  useEffect(() => {
+    // requisição pra pegar valores do user/página
+    // const baseURL = "https://api.w3block.io";
+    // const location = "primesea.io";
+    // const url = `${baseURL}/storeFrontPage?site=${location}&path=${pageName}`;
+
+    setPageTheme(sampleTemplateData);
+  }, [pageName]);
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        defaultTheme,
+        pageTheme,
+        setPageName,
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+const sampleTemplate: Template = {
+  header: {
+    bgColor: 'rgba(255,127,127,0.5)',
+    textColor: 'rgba(20,10,255,1)',
+  },
+  banner: {
+    bgColor: 'rgba(255,127,127,0.5)',
+    textColor: 'rgba(20,10,255,1)',
+  },
+};
+
+const sampleTemplateData: TemplateData = {
+  title: 'Home page',
+  items: [
+    {
+      type: 'header',
+      props: {
+        brandText: 'W3block Storefront Custom',
+        bgColor: 'rgba(255,127,127,0.5)',
+        textColor: 'rgba(20,10,255,1)',
+        links: [
+          {
+            label: 'Sobre',
+            type: 'internal',
+            value: 'about',
+            newWindow: false,
+          },
+          {
+            label: 'Nossos parceiros',
+            type: 'external',
+            value: 'https://www.nossosparceiros.com.br',
+            newWindow: true,
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/src/modules/storefront/contexts/ThemeContext/ThemeContext.tsx
+++ b/src/modules/storefront/contexts/ThemeContext/ThemeContext.tsx
@@ -17,7 +17,7 @@ interface IThemeContext {
   setPageName: Dispatch<SetStateAction<string>>;
 }
 
-export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [defaultTheme, setDefaultTheme] = useState<Template | null>(null);
   const [pageTheme, setPageTheme] = useState<TemplateData | null>(null);
   const [pageName, setPageName] = useState('');
@@ -52,10 +52,6 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   );
 };
 
-interface ThemeProviderProps {
-  children: ReactNode;
-}
-
 const sampleTemplate: Template = {
   header: {
     bgColor: 'rgba(255,127,127,0.5)',
@@ -64,6 +60,9 @@ const sampleTemplate: Template = {
   banner: {
     bgColor: 'rgba(255,127,127,0.5)',
     textColor: 'rgba(20,10,255,1)',
+  },
+  hero: {
+    data: 'text',
   },
 };
 

--- a/src/modules/storefront/contexts/ThemeContext/index.ts
+++ b/src/modules/storefront/contexts/ThemeContext/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeContext';

--- a/src/modules/storefront/contexts/index.ts
+++ b/src/modules/storefront/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeContext';

--- a/src/modules/storefront/index.ts
+++ b/src/modules/storefront/index.ts
@@ -1,0 +1,1 @@
+export * from './components';

--- a/src/modules/storefront/interfaces/index.ts
+++ b/src/modules/storefront/interfaces/index.ts
@@ -1,14 +1,21 @@
 export interface TemplateData {
   title: string;
   items: {
-    type: ComponentType;
-    props: HeaderData | BannerData;
+    type: keyof Template;
+    props: HeaderData | BannerData | HeroData;
   }[];
 }
+
+export type DefaultDataProps = HeaderProps | BannerProps | HeroProps;
+
+type HeaderProps = { data: HeaderData; defaultData: HeaderDefault };
+type BannerProps = { data: BannerData; defaultData: BannerDefault };
+type HeroProps = { data: HeroData; defaultData: HeroDefault };
 
 export interface Template {
   header: HeaderDefault;
   banner: BannerDefault;
+  hero: HeroDefault;
 }
 
 export type HeaderData = {
@@ -34,6 +41,14 @@ export type BannerDefault = {
   textColor: string;
 };
 
+export type HeroData = {
+  data?: string;
+};
+
+export type HeroDefault = {
+  data: string;
+};
+
 type CategoryItem = { label: string; slug: string };
 type HeaderLink = {
   label: string;
@@ -41,5 +56,3 @@ type HeaderLink = {
   value: string;
   newWindow: boolean;
 };
-
-type ComponentType = 'header' | 'banner';

--- a/src/modules/storefront/interfaces/index.ts
+++ b/src/modules/storefront/interfaces/index.ts
@@ -1,0 +1,45 @@
+export interface TemplateData {
+  title: string;
+  items: {
+    type: ComponentType;
+    props: HeaderData | BannerData;
+  }[];
+}
+
+export interface Template {
+  header: HeaderDefault;
+  banner: BannerDefault;
+}
+
+export type HeaderData = {
+  brandText?: string;
+  bgColor?: string;
+  textColor?: string;
+  links?: HeaderLink[];
+};
+
+export type HeaderDefault = {
+  bgColor: string;
+  textColor: string;
+};
+
+export type BannerData = {
+  bgColor?: string;
+  textColor?: string;
+  categories?: CategoryItem[];
+};
+
+export type BannerDefault = {
+  bgColor: string;
+  textColor: string;
+};
+
+type CategoryItem = { label: string; slug: string };
+type HeaderLink = {
+  label: string;
+  type: 'internal' | 'external';
+  value: string;
+  newWindow: boolean;
+};
+
+type ComponentType = 'header' | 'banner';


### PR DESCRIPTION
- HeaderPixway alterado para utilizar `brandText`
- Criado um `context` para tema global e tema da página de preview
- Criado componente `StorefrontPreview` que renderiza a listagem de componentes dinamicamente baseado no tipo de componente. Ex: header, banner, hero...
- Implementação parcial de listener para receber valores do tema dinamicamente